### PR TITLE
Support waiting for ACK response

### DIFF
--- a/include/pulsar/ConsumerConfiguration.h
+++ b/include/pulsar/ConsumerConfiguration.h
@@ -629,6 +629,22 @@ class PULSAR_PUBLIC ConsumerConfiguration {
 
     const std::vector<ConsumerInterceptorPtr>& getInterceptors() const;
 
+    /**
+     * Whether to receive the ACK receipt from broker.
+     *
+     * By default, when Consumer::acknowledge is called, it won't wait until the corresponding response from
+     * broker. After it's enabled, the `acknowledge` method will return a Result that indicates if the
+     * acknowledgment succeeded.
+     *
+     * Default: false
+     */
+    ConsumerConfiguration& setAckReceiptEnabled(bool ackReceiptEnabled);
+
+    /**
+     * The associated getter of setAckReceiptEnabled.
+     */
+    bool isAckReceiptEnabled() const;
+
     friend class PulsarWrapper;
     friend class PulsarFriend;
 

--- a/lib/AckGroupingTracker.cc
+++ b/lib/AckGroupingTracker.cc
@@ -19,6 +19,9 @@
 
 #include "AckGroupingTracker.h"
 
+#include <atomic>
+#include <limits>
+
 #include "BitSet.h"
 #include "ClientConnection.h"
 #include "Commands.h"
@@ -29,24 +32,31 @@ namespace pulsar {
 
 DECLARE_LOG_OBJECT();
 
-inline void sendAck(ClientConnectionPtr cnx, uint64_t consumerId, const MessageId& msgId,
-                    CommandAck_AckType ackType) {
-    const auto& bitSet = Commands::getMessageIdImpl(msgId)->getBitSet();
-    auto cmd = Commands::newAck(consumerId, msgId.ledgerId(), msgId.entryId(), bitSet, ackType, -1);
-    cnx->sendCommand(cmd);
-    LOG_DEBUG("ACK request is sent for message - [" << msgId.ledgerId() << ", " << msgId.entryId() << "]");
-}
-
-bool AckGroupingTracker::doImmediateAck(ClientConnectionWeakPtr connWeakPtr, uint64_t consumerId,
-                                        const MessageId& msgId, CommandAck_AckType ackType) {
-    auto cnx = connWeakPtr.lock();
-    if (cnx == nullptr) {
-        LOG_DEBUG("Connection is not ready, ACK failed for message - [" << msgId.ledgerId() << ", "
-                                                                        << msgId.entryId() << "]");
-        return false;
+void AckGroupingTracker::doImmediateAck(const MessageId& msgId, ResultCallback callback,
+                                        CommandAck_AckType ackType) const {
+    const auto cnx = connectionSupplier_();
+    if (!cnx) {
+        LOG_DEBUG("Connection is not ready, ACK failed for " << msgId);
+        if (callback) {
+            callback(ResultAlreadyClosed);
+        }
+        return;
     }
-    sendAck(cnx, consumerId, msgId, ackType);
-    return true;
+    const auto requestId = (waitResponse_ ? requestIdSupplier_() : std::numeric_limits<uint64_t>::max());
+    const auto cmd = Commands::newAck(consumerId_, msgId.ledgerId(), msgId.entryId(),
+                                      Commands::getMessageIdImpl(msgId)->getBitSet(), ackType, requestId);
+    if (waitResponse_) {
+        cnx->sendRequestWithId(cmd, requestId).addListener([callback](Result result, const ResponseData&) {
+            if (callback) {
+                callback(result);
+            }
+        });
+    } else {
+        cnx->sendCommand(cmd);
+        if (callback) {
+            callback(ResultOk);
+        }
+    }
 }
 
 static std::ostream& operator<<(std::ostream& os, const std::set<MessageId>& msgIds) {
@@ -62,25 +72,35 @@ static std::ostream& operator<<(std::ostream& os, const std::set<MessageId>& msg
     return os;
 }
 
-bool AckGroupingTracker::doImmediateAck(ClientConnectionWeakPtr connWeakPtr, uint64_t consumerId,
-                                        const std::set<MessageId>& msgIds) {
-    auto cnx = connWeakPtr.lock();
-    if (cnx == nullptr) {
-        LOG_DEBUG("Connection is not ready, ACK failed.");
-        return false;
+void AckGroupingTracker::doImmediateAck(const std::set<MessageId>& msgIds, ResultCallback callback) const {
+    const auto cnx = connectionSupplier_();
+    if (!cnx) {
+        LOG_DEBUG("Connection is not ready, ACK failed for " << msgIds);
+        if (callback) {
+            callback(ResultAlreadyClosed);
+        }
+        return;
     }
 
-    if (Commands::peerSupportsMultiMessageAcknowledgement(cnx->getServerProtocolVersion())) {
-        auto cmd = Commands::newMultiMessageAck(consumerId, msgIds);
-        cnx->sendCommand(cmd);
-        LOG_DEBUG("ACK request is sent for " << msgIds.size() << " messages: " << msgIds);
+    if (waitResponse_ && Commands::peerSupportsMultiMessageAcknowledgement(cnx->getServerProtocolVersion())) {
+        const auto requestId = requestIdSupplier_();
+        const auto cmd = Commands::newMultiMessageAck(consumerId_, msgIds, requestId);
+        cnx->sendRequestWithId(cmd, requestId).addListener([callback](Result result, const ResponseData&) {
+            if (callback) {
+                callback(result);
+            }
+        });
     } else {
-        // Broker does not support multi-message ACK, use multiple individual ACKs instead.
-        for (const auto& msgId : msgIds) {
-            sendAck(cnx, consumerId, msgId, CommandAck_AckType_Individual);
+        auto count = std::make_shared<std::atomic<size_t>>(msgIds.size());
+        auto wrappedCallback = [callback, count](Result result) {
+            if (--*count == 0 && callback) {
+                callback(result);
+            }
+        };
+        for (auto&& msgId : msgIds) {
+            doImmediateAck(msgId, wrappedCallback, CommandAck_AckType_Individual);
         }
     }
-    return true;
 }
 
 }  // namespace pulsar

--- a/lib/AckGroupingTracker.cc
+++ b/lib/AckGroupingTracker.cc
@@ -95,6 +95,9 @@ void AckGroupingTracker::doImmediateAck(const std::set<MessageId>& msgIds, Resul
                 });
         } else {
             cnx->sendCommand(Commands::newMultiMessageAck(consumerId_, msgIds));
+            if (callback) {
+                callback(ResultOk);
+            }
         }
     } else {
         auto count = std::make_shared<std::atomic<size_t>>(msgIds.size());

--- a/lib/AckGroupingTrackerDisabled.cc
+++ b/lib/AckGroupingTrackerDisabled.cc
@@ -20,32 +20,24 @@
 #include "AckGroupingTrackerDisabled.h"
 
 #include "HandlerBase.h"
-#include "LogUtils.h"
 #include "ProtoApiEnums.h"
 
 namespace pulsar {
 
-DECLARE_LOG_OBJECT();
-
-AckGroupingTrackerDisabled::AckGroupingTrackerDisabled(HandlerBase& handler, uint64_t consumerId)
-    : AckGroupingTracker(), handler_(handler), consumerId_(consumerId) {
-    LOG_INFO("ACK grouping is disabled.");
+void AckGroupingTrackerDisabled::addAcknowledge(const MessageId& msgId, ResultCallback callback) {
+    doImmediateAck(msgId, callback, CommandAck_AckType_Individual);
 }
 
-void AckGroupingTrackerDisabled::addAcknowledge(const MessageId& msgId) {
-    this->doImmediateAck(this->handler_.getCnx(), this->consumerId_, msgId, CommandAck_AckType_Individual);
-}
-
-void AckGroupingTrackerDisabled::addAcknowledgeList(const MessageIdList& msgIds) {
+void AckGroupingTrackerDisabled::addAcknowledgeList(const MessageIdList& msgIds, ResultCallback callback) {
     std::set<MessageId> msgIdSet;
     for (auto&& msgId : msgIds) {
         msgIdSet.emplace(msgId);
     }
-    this->doImmediateAck(this->handler_.getCnx(), this->consumerId_, msgIdSet);
+    doImmediateAck(msgIdSet, callback);
 }
 
-void AckGroupingTrackerDisabled::addAcknowledgeCumulative(const MessageId& msgId) {
-    this->doImmediateAck(this->handler_.getCnx(), this->consumerId_, msgId, CommandAck_AckType_Cumulative);
+void AckGroupingTrackerDisabled::addAcknowledgeCumulative(const MessageId& msgId, ResultCallback callback) {
+    doImmediateAck(msgId, callback, CommandAck_AckType_Cumulative);
 }
 
 }  // namespace pulsar

--- a/lib/AckGroupingTrackerDisabled.h
+++ b/lib/AckGroupingTrackerDisabled.h
@@ -34,25 +34,12 @@ class HandlerBase;
  */
 class AckGroupingTrackerDisabled : public AckGroupingTracker {
    public:
+    using AckGroupingTracker::AckGroupingTracker;
     virtual ~AckGroupingTrackerDisabled() = default;
 
-    /**
-     * Constructing ACK grouping tracker for peresistent topics that disabled ACK grouping.
-     * @param[in] handler the connection handler.
-     * @param[in] consumerId consumer ID that this tracker belongs to.
-     */
-    AckGroupingTrackerDisabled(HandlerBase& handler, uint64_t consumerId);
-
-    void addAcknowledge(const MessageId& msgId) override;
-    void addAcknowledgeList(const MessageIdList& msgIds) override;
-    void addAcknowledgeCumulative(const MessageId& msgId) override;
-
-   private:
-    //! The connection handler.
-    HandlerBase& handler_;
-
-    //! ID of the consumer that this tracker belongs to.
-    uint64_t consumerId_;
+    void addAcknowledge(const MessageId& msgId, ResultCallback callback) override;
+    void addAcknowledgeList(const MessageIdList& msgIds, ResultCallback callback) override;
+    void addAcknowledgeCumulative(const MessageId& msgId, ResultCallback callback) override;
 };  // class AckGroupingTrackerDisabled
 
 }  // namespace pulsar

--- a/lib/ClientConnection.h
+++ b/lib/ClientConnection.h
@@ -75,6 +75,7 @@ struct OpSendMsg;
 namespace proto {
 class BaseCommand;
 class CommandActiveConsumerChange;
+class CommandAckResponse;
 class CommandMessage;
 class CommandCloseConsumer;
 class CommandCloseProducer;
@@ -390,6 +391,7 @@ class PULSAR_PUBLIC ClientConnection : public std::enable_shared_from_this<Clien
     void handleGetLastMessageIdResponse(const proto::CommandGetLastMessageIdResponse&);
     void handleGetTopicOfNamespaceResponse(const proto::CommandGetTopicsOfNamespaceResponse&);
     void handleGetSchemaResponse(const proto::CommandGetSchemaResponse&);
+    void handleAckResponse(const proto::CommandAckResponse&);
 };
 }  // namespace pulsar
 

--- a/lib/ClientImpl.cc
+++ b/lib/ClientImpl.cc
@@ -92,7 +92,6 @@ ClientImpl::ClientImpl(const std::string& serviceUrl, const ClientConfiguration&
       pool_(clientConfiguration_, ioExecutorProvider_, clientConfiguration_.getAuthPtr(), poolConnections),
       producerIdGenerator_(0),
       consumerIdGenerator_(0),
-      requestIdGenerator_(0),
       closingError(ResultOk) {
     std::unique_ptr<LoggerFactory> loggerFactory = clientConfiguration_.impl_->takeLogger();
     if (!loggerFactory) {
@@ -713,10 +712,7 @@ uint64_t ClientImpl::newConsumerId() {
     return consumerIdGenerator_++;
 }
 
-uint64_t ClientImpl::newRequestId() {
-    Lock lock(mutex_);
-    return requestIdGenerator_++;
-}
+uint64_t ClientImpl::newRequestId() { return (*requestIdGenerator_)++; }
 
 uint64_t ClientImpl::getNumberOfProducers() {
     uint64_t numberOfAliveProducers = 0;

--- a/lib/ClientImpl.h
+++ b/lib/ClientImpl.h
@@ -121,6 +121,8 @@ class ClientImpl : public std::enable_shared_from_this<ClientImpl> {
 
     void cleanupConsumer(ConsumerImplBase* address) { consumers_.remove(address); }
 
+    std::shared_ptr<std::atomic<uint64_t>> getRequestIdGenerator() const { return requestIdGenerator_; }
+
     friend class PulsarFriend;
 
    private:
@@ -175,7 +177,7 @@ class ClientImpl : public std::enable_shared_from_this<ClientImpl> {
 
     uint64_t producerIdGenerator_;
     uint64_t consumerIdGenerator_;
-    uint64_t requestIdGenerator_;
+    std::shared_ptr<std::atomic<uint64_t>> requestIdGenerator_{std::make_shared<std::atomic<uint64_t>>(0)};
 
     SynchronizedHashMap<ProducerImplBase*, ProducerImplBaseWeakPtr> producers_;
     SynchronizedHashMap<ConsumerImplBase*, ConsumerImplBaseWeakPtr> consumers_;

--- a/lib/Commands.h
+++ b/lib/Commands.h
@@ -117,8 +117,9 @@ class Commands {
                                     const std::string& initialSubscriptionName);
 
     static SharedBuffer newAck(uint64_t consumerId, int64_t ledgerId, int64_t entryId, const BitSet& ackSet,
-                               CommandAck_AckType ackType, CommandAck_ValidationError validationError);
-    static SharedBuffer newMultiMessageAck(uint64_t consumerId, const std::set<MessageId>& msgIds);
+                               CommandAck_AckType ackType, uint64_t requestId);
+    static SharedBuffer newMultiMessageAck(uint64_t consumerId, const std::set<MessageId>& msgIds,
+                                           uint64_t requestId);
 
     static SharedBuffer newFlow(uint64_t consumerId, uint32_t messagePermits);
 

--- a/lib/Commands.h
+++ b/lib/Commands.h
@@ -117,7 +117,13 @@ class Commands {
                                     const std::string& initialSubscriptionName);
 
     static SharedBuffer newAck(uint64_t consumerId, int64_t ledgerId, int64_t entryId, const BitSet& ackSet,
+                               CommandAck_AckType ackType);
+    static SharedBuffer newAck(uint64_t consumerId, int64_t ledgerId, int64_t entryId, const BitSet& ackSet,
                                CommandAck_AckType ackType, uint64_t requestId);
+    static SharedBuffer newAck(uint64_t consumerId, int64_t ledgerId, int64_t entryId, const BitSet& ackSet,
+                               CommandAck_AckType ackType, CommandAck_ValidationError validationError);
+
+    static SharedBuffer newMultiMessageAck(uint64_t consumerId, const std::set<MessageId>& msgIds);
     static SharedBuffer newMultiMessageAck(uint64_t consumerId, const std::set<MessageId>& msgIds,
                                            uint64_t requestId);
 

--- a/lib/ConsumerConfiguration.cc
+++ b/lib/ConsumerConfiguration.cc
@@ -310,4 +310,11 @@ const std::vector<ConsumerInterceptorPtr>& ConsumerConfiguration::getInterceptor
     return impl_->interceptors;
 }
 
+ConsumerConfiguration& ConsumerConfiguration::setAckReceiptEnabled(bool ackReceiptEnabled) {
+    impl_->ackReceiptEnabled = ackReceiptEnabled;
+    return *this;
+}
+
+bool ConsumerConfiguration::isAckReceiptEnabled() const { return impl_->ackReceiptEnabled; }
+
 }  // namespace pulsar

--- a/lib/ConsumerConfigurationImpl.h
+++ b/lib/ConsumerConfigurationImpl.h
@@ -59,6 +59,7 @@ struct ConsumerConfigurationImpl {
     long expireTimeOfIncompleteChunkedMessageMs{60000};
     bool batchIndexAckEnabled{false};
     std::vector<ConsumerInterceptorPtr> interceptors;
+    bool ackReceiptEnabled{false};
 };
 }  // namespace pulsar
 #endif /* LIB_CONSUMERCONFIGURATIONIMPL_H_ */

--- a/tests/ConsumerConfigurationTest.cc
+++ b/tests/ConsumerConfigurationTest.cc
@@ -70,6 +70,7 @@ TEST(ConsumerConfigurationTest, testDefaultConfig) {
     ASSERT_EQ(conf.getBatchReceivePolicy().getMaxNumBytes(), 10 * 1024 * 1024);
     ASSERT_EQ(conf.getBatchReceivePolicy().getTimeoutMs(), 100);
     ASSERT_EQ(conf.isBatchIndexAckEnabled(), false);
+    ASSERT_EQ(conf.isAckReceiptEnabled(), false);
 }
 
 TEST(ConsumerConfigurationTest, testCustomConfig) {
@@ -168,6 +169,9 @@ TEST(ConsumerConfigurationTest, testCustomConfig) {
 
     conf.setBatchIndexAckEnabled(true);
     ASSERT_EQ(conf.isBatchIndexAckEnabled(), true);
+
+    conf.setAckReceiptEnabled(true);
+    ASSERT_TRUE(conf.isAckReceiptEnabled());
 }
 
 TEST(ConsumerConfigurationTest, testReadCompactPersistentExclusive) {

--- a/tests/InterceptorsTest.cc
+++ b/tests/InterceptorsTest.cc
@@ -21,6 +21,7 @@
 #include <pulsar/ConsumerInterceptor.h>
 #include <pulsar/ProducerInterceptor.h>
 
+#include <random>
 #include <utility>
 
 #include "HttpHelper.h"
@@ -31,6 +32,8 @@ DECLARE_LOG_OBJECT()
 
 static const std::string serviceUrl = "pulsar://localhost:6650";
 static const std::string adminUrl = "http://localhost:8080/";
+
+extern std::string unique_str();
 
 using namespace pulsar;
 
@@ -272,8 +275,7 @@ class ConsumerTestInterceptor : public ConsumerInterceptor {
 class ConsumerInterceptorsTest : public ::testing::TestWithParam<std::tuple<TopicType, int>> {
    public:
     void SetUp() override {
-        topic_ = "persistent://public/default/InterceptorsTest-ConsumerInterceptors-" +
-                 std::to_string(time(nullptr));
+        topic_ = "persistent://public/default/InterceptorsTest-ConsumerInterceptors-" + unique_str();
 
         switch (std::get<0>(GetParam())) {
             case Partitioned:


### PR DESCRIPTION
TODO:
- Reuse the logic to convert vector<pair<MessageId, ResultCallback> to a map.
- Fix the callback in AckGroupingTrackerEnabled not triggered in time